### PR TITLE
Use inline badge image rather than big logo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ inflect.py
     :target: https://travis-ci.org/jazzband/inflect
 .. image:: https://coveralls.io/repos/github/jazzband/inflect/badge.svg?branch=master
     :target: https://coveralls.io/github/jazzband/inflect?branch=master
-.. image:: https://jazzband.co/static/img/jazzband.svg
+.. image:: https://jazzband.co/static/img/badge.svg
    :target: https://jazzband.co/
    :alt: Jazzband
 


### PR DESCRIPTION
From https://jazzband.co/about/guidelines#badges

## Before

![image](https://user-images.githubusercontent.com/1324225/39804087-c3eb7022-537b-11e8-889e-274fc0c40e66.png)

## After

![image](https://user-images.githubusercontent.com/1324225/39804067-b8525aa0-537b-11e8-8c1f-e27abbee0de5.png)

